### PR TITLE
Removing support for new tips and linking to gifts

### DIFF
--- a/bctip/urls.py
+++ b/bctip/urls.py
@@ -8,7 +8,7 @@ admin.autodiscover()
 
 urlpatterns = i18n_patterns('',
     url(r'^$', 'core.views.home', name='home'),
-    url(r'^new/$', 'core.views.new', name='new'),
+    #url(r'^new/$', 'core.views.new', name='new'),
     url(r'^statistics/$', 'core.views.statistics', name='statistics'),
     url(r'^(?P<key>\w+-\w+-\w+-\w+-\w+)$', 'core.views.tip_redir'),
     url(r'^(?P<key>\w+-\w+-\w+-\w+-\w+)/$', 'core.views.tip'),

--- a/core/templates/base.html
+++ b/core/templates/base.html
@@ -60,7 +60,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
       <div class="col-md-12">
         <h3 class="h3-line">Give Bitcoin Cash (BCH) Without Losing Unclaimed Funds</h3> 
         <h1>Bitcoin Cash (BCH) Tips</h1>  
-        <a class="btn btn-primary" href="{% url "new" %}">Generate New</a>
+        <a class="btn btn-primary" href="https://gifts.bitcoin.com/" >Tips is moving to Gifts</a>
       </div>
     </div>
       <nav id="main-nav">

--- a/core/templates/index.html
+++ b/core/templates/index.html
@@ -2,8 +2,14 @@
 {% block nav_main %}active{%endblock%}
 {% block content %}
 
+<div style="padding:12px; border: 2px solid #0fcb97; border-radius: 5px; margin: 24px 0px; background-color:rgb(15, 203, 151, 0.1)">
+<h1>Bitcoin.com Tips is moving to Gifts</h1>
+<p id="gifts-info">
+  Visit <a href="https://gifts.bitcoin.com/">gifts.bitcoin.com</a> to create BCH gifts that can be redeemed by scanning with a wallet (unclaimed gifts are automatically returned!)
+</p>
+<p>Tips created with tips.bitcoin.com will still work and be automatically returned on expiration, but creating new tips is no longer supported.</p>
+</div>
 <h1>What are Bitcoin.com Tips?</h1>
-
 <p id="intro-info">
   Create tips to give Bitcoin Cash (BCH) by email or printable tickets. Recipients redeem tips by visiting a web page with instructions <a href="{% url "tips_example" %}">(example)</a>.
 </p>
@@ -49,9 +55,7 @@
 <center>
     <h1>Unclaimed tips are automatically returned!</h1>        
   
-    <a class="btn btn-primary" href="{% url "new" %}">Get Started</a>
-
-    <br><br>
+    
  
     <a href="https://bitcoincash.org/" target="_blank">What is Bitcoin Cash?</a>
 


### PR DESCRIPTION
Disabling new tip creation to prepare for deprecation, to be replaced by gifts.bitcoin.com (repo open source at https://github.com/Bitcoin-com/gifts-frontend)